### PR TITLE
add demostration for auto-removing zero-length text markers

### DIFF
--- a/TextMarkerSample/SharpDevelop/ITextMarker.cs
+++ b/TextMarkerSample/SharpDevelop/ITextMarker.cs
@@ -98,8 +98,14 @@ namespace ICSharpCode.SharpDevelop.Editor
 		/// </summary>
 		/// <remarks>Not supported in this sample!</remarks>
 		object ToolTip { get; set; }
+
+		/// <summary>
+		/// Gets/sets if this marker will remove itself from the owning collection if it's <see cref="Length"/> changes to zero.
+		/// </summary>
+		bool RemoveZeroLength { get; set; }
+
 	}
-	
+
 	[Flags]
 	public enum TextMarkerTypes
 	{

--- a/TextMarkerSample/Window1.xaml.cs
+++ b/TextMarkerSample/Window1.xaml.cs
@@ -40,7 +40,7 @@ namespace TextMarkerSample
 		
 		void InitializeTextMarkerService()
 		{
-			var textMarkerService = new TextMarkerService(textEditor.Document);
+			var textMarkerService = new TextMarkerService(textEditor.Document, textEditor.Dispatcher);
 			textEditor.TextArea.TextView.BackgroundRenderers.Add(textMarkerService);
 			textEditor.TextArea.TextView.LineTransformers.Add(textMarkerService);
 			IServiceContainer services = (IServiceContainer)textEditor.Document.ServiceProvider.GetService(typeof(IServiceContainer));
@@ -64,6 +64,7 @@ namespace TextMarkerSample
 			ITextMarker marker = textMarkerService.Create(textEditor.SelectionStart, textEditor.SelectionLength);
 			marker.MarkerTypes = TextMarkerTypes.SquigglyUnderline;
 			marker.MarkerColor = Colors.Red;
+			marker.RemoveZeroLength = true;
 		}
 		
 		bool IsSelected(ITextMarker marker)


### PR DESCRIPTION
I know this is an **old** sample, still submitting this PR ;) It would have helped me - hoping it will help someone else.

It's basically my bare-bones demonstration of a working removal of `TextSegment`s/Markers which have reached zero-length without any change to AvalonEdit.